### PR TITLE
Enable Consistent Logs from Containers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-docker==2.1.0
+docker

--- a/swarm.py
+++ b/swarm.py
@@ -60,7 +60,7 @@ class SwarmManager(object):
         if mountdir is not None:
             mounts.append('%s:/share:rw' % mountdir)
         return self.docker_client.services.create(image, command, name=name, mounts=mounts,
-                                                  restart_policy=restart_policy)
+                                                  restart_policy=restart_policy, tty=True)
 
     def get_service(self, name):
         """


### PR DESCRIPTION
Initially, logs from containers were only available after they finished execution as it returned empty logs until then. Setting the `tty` parameter to `True` instead allows current logs to be fetched at any time. Additionally, the docker version in `requirements.txt` did not support this functionality so I had to change it to the latest version. 

With this `swarm` docker image, `pfcon` is able to get the most recent logs of jobs. I tested this with the `pl-heartbeat` plugin, which returns system information every few seconds.  After submitting a pfcon job with this plugin, I was able to get accurate logs consistently. However, before this change, I only got the logs after the job finished execution, not during its execution.